### PR TITLE
Default rfpower

### DIFF
--- a/make/Makerules
+++ b/make/Makerules
@@ -322,6 +322,7 @@ $(BUILD_DIR)/%.o: %.c $(BUILD_DIR)/%.d Makefile | $(BUILD_DIR)
 # endif
 
 $(call passVarToCpp,CFLAGS,BOOTLOADER_START)
+$(call passVarToCpp,CFLAGS,BOOTLOADER_MAX_LEN)
 $(call passVarToCpp,CFLAGS,STAGE1_START)
 $(call passVarToCpp,CFLAGS,STAGE1_MAX_LEN)
 $(call passVarToCpp,CFLAGS,STAGE2_START)

--- a/make/architectures/efr32-common.arch
+++ b/make/architectures/efr32-common.arch
@@ -12,3 +12,7 @@ TC_SIZE                 := $(TOOLCHAIN)size
 
 # Define common MCU architecture flags for the compiler
 CFLAGS                  += -mthumb -mthumb-interwork
+
+# +10dBm should be supported by all 2.4GHz Series 1 and 2 EFR32 chips
+DEFAULT_RFPOWER_DBM ?= 10
+$(call passVarToCpp,CFLAGS,DEFAULT_RFPOWER_DBM)


### PR DESCRIPTION
Need to do some CFLAGS var passing somewhere. Arch common seems to be the best place, so set a reasonable default there as well. Boards will set their own values, but not pass to CFLAGS.