### PR TITLE
M33

### DIFF
--- a/make/architectures/efr32xg1x.arch
+++ b/make/architectures/efr32xg1x.arch
@@ -10,4 +10,14 @@ MCU_SIGDATA_ADDR         = 0xfe00000
 MCU_SIGDATA_SIZE         = 2048
 MCU_ARCH                 = efr32xg1x
 
-CFLAGS                  += -mcpu=cortex-m4 -mfloat-abi=soft -DEFR32_SERIES1
+CFLAGS                  += -DEFR32_SERIES1
+CFLAGS                  += -mcpu=cortex-m4
+
+FPU_SOFT ?= 0 # Set to 1 to use float-abi=soft and M3 ports for FreeRTOS
+ifeq ($(FPU_SOFT),1)
+    CFLAGS                  += -mfloat-abi=soft
+else
+    CFLAGS                  += -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -DARM_MATH_CM4=1 -D__FPU_PRESENT=1U
+    LDLIBS += $(SILABS_SDKDIR)/platform/CMSIS/Lib/GCC/libarm_cortexM4lf_math.a
+endif
+

--- a/make/architectures/efr32xg2x.arch
+++ b/make/architectures/efr32xg2x.arch
@@ -11,7 +11,6 @@ MCU_SIGDATA_SIZE         = 1024
 MCU_ARCH                 = efr32xg2x
 
 CFLAGS                  += -mcpu=cortex-m33
-CFLAGS                  += -mthumb
 CFLAGS                  += -mfloat-abi=hard
 CFLAGS                  += -mfpu=fpv5-sp-d16
 CFLAGS                  += -mcmse

--- a/make/architectures/efr32xg2x.arch
+++ b/make/architectures/efr32xg2x.arch
@@ -10,4 +10,10 @@ MCU_SIGDATA_ADDR         = 0xfe00000
 MCU_SIGDATA_SIZE         = 1024
 MCU_ARCH                 = efr32xg2x
 
-CFLAGS                  += -mcpu=cortex-m33 -mfloat-abi=hard -DEFR32_SERIES2
+CFLAGS                  += -mcpu=cortex-m33
+CFLAGS                  += -mthumb
+CFLAGS                  += -mfloat-abi=hard
+CFLAGS                  += -mfpu=fpv5-sp-d16
+CFLAGS                  += -mcmse
+
+CFLAGS                  += -DEFR32_SERIES2


### PR DESCRIPTION
S1 can be built with FPU or without. Using FPU requires M4F FreeRTOS port, but M3 port must be used when FPU is not used. Default to FPU port.