### PR TITLE
Use correct math library for softfp EFR32 S1.

### DIFF
--- a/make/architectures/efr32xg1x.arch
+++ b/make/architectures/efr32xg1x.arch
@@ -15,9 +15,9 @@ CFLAGS                  += -mcpu=cortex-m4
 
 FPU_SOFT ?= 0 # Set to 1 to use float-abi=soft and M3 ports for FreeRTOS
 ifeq ($(FPU_SOFT),1)
-    CFLAGS                  += -mfloat-abi=soft
+    CFLAGS              += -mfloat-abi=soft
 else
-    CFLAGS                  += -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -DARM_MATH_CM4=1 -D__FPU_PRESENT=1U
-    LDLIBS += $(SILABS_SDKDIR)/platform/CMSIS/Lib/GCC/libarm_cortexM4lf_math.a
+    CFLAGS              += -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -DARM_MATH_CM4=1 -D__FPU_PRESENT=1U
+    LDLIBS              += $(SILABS_SDKDIR)/platform/CMSIS/Lib/GCC/libarm_cortexM4l_math.a
 endif
 


### PR DESCRIPTION
Turns out we had the wrong one listed and nothing was actually using any of the functions. Not actually convinced this one uses all the HW features as SiLabs has done something suspicious with their libraries, however the other one cannot be used together with RAIL, which is only available with soft fp.